### PR TITLE
Fix Bytes.Decode

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,2 +1,3 @@
 Robin Heggelund Hansen
 Gaute Berge
+Atle Wee Førre

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The goal of this package is to support **network protocols** such as ProtoBuf. O
 
 This package lets you create encoders and decoders for working with sequences of bytes. Here is an example for converting between `Point` and `Bytes` values:
 
-```elm
+```gren
 import Bytes exposing (Endianness(..))
 import Bytes.Encode as Encode exposing (Encoder)
 import Bytes.Decode as Decode exposing (Decoder)

--- a/gren.json
+++ b/gren.json
@@ -3,7 +3,7 @@
     "name": "gren-lang/bytes",
     "summary": "Work with sequences of bytes (a.k.a. ArrayBuffer, typed arrays, DataView)",
     "license": "BSD-3-Clause",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "exposed-modules": [
         "Bytes",
         "Bytes.Encode",

--- a/src/Gren/Kernel/Bytes.js
+++ b/src/Gren/Kernel/Bytes.js
@@ -2,7 +2,7 @@
 
 import Bytes.Encode as Encode exposing (getWidth, write)
 import Gren.Kernel.Scheduler exposing (binding, succeed)
-import Gren.Kernel.Utils exposing (Tuple2, chr)
+import Gren.Kernel.Utils exposing (chr)
 import Maybe exposing (Just, Nothing)
 
 */
@@ -129,24 +129,24 @@ var _Bytes_write_string = F3(function(mb, offset, string)
 var _Bytes_decode = F2(function(decoder, bytes)
 {
 	try {
-		return __Maybe_Just(A2(decoder, bytes, 0).b);
+		return __Maybe_Just(A2(decoder, bytes, 0).value);
 	} catch(e) {
 		return __Maybe_Nothing;
 	}
 });
 
-var _Bytes_read_i8  = F2(function(      bytes, offset) { return __Utils_Tuple2(offset + 1, bytes.getInt8(offset)); });
-var _Bytes_read_i16 = F3(function(isLE, bytes, offset) { return __Utils_Tuple2(offset + 2, bytes.getInt16(offset, isLE)); });
-var _Bytes_read_i32 = F3(function(isLE, bytes, offset) { return __Utils_Tuple2(offset + 4, bytes.getInt32(offset, isLE)); });
-var _Bytes_read_u8  = F2(function(      bytes, offset) { return __Utils_Tuple2(offset + 1, bytes.getUint8(offset)); });
-var _Bytes_read_u16 = F3(function(isLE, bytes, offset) { return __Utils_Tuple2(offset + 2, bytes.getUint16(offset, isLE)); });
-var _Bytes_read_u32 = F3(function(isLE, bytes, offset) { return __Utils_Tuple2(offset + 4, bytes.getUint32(offset, isLE)); });
-var _Bytes_read_f32 = F3(function(isLE, bytes, offset) { return __Utils_Tuple2(offset + 4, bytes.getFloat32(offset, isLE)); });
-var _Bytes_read_f64 = F3(function(isLE, bytes, offset) { return __Utils_Tuple2(offset + 8, bytes.getFloat64(offset, isLE)); });
+var _Bytes_read_i8  = F2(function(      bytes, offset) { return {offset: offset + 1, value: bytes.getInt8(offset)}; });
+var _Bytes_read_i16 = F3(function(isLE, bytes, offset) { return {offset: offset + 2, value: bytes.getInt16(offset, isLE)}; });
+var _Bytes_read_i32 = F3(function(isLE, bytes, offset) { return {offset: offset + 4, value: bytes.getInt32(offset, isLE)}; });
+var _Bytes_read_u8  = F2(function(      bytes, offset) { return {offset: offset + 1, value: bytes.getUint8(offset)}; });
+var _Bytes_read_u16 = F3(function(isLE, bytes, offset) { return {offset: offset + 2, value: bytes.getUint16(offset, isLE)}; });
+var _Bytes_read_u32 = F3(function(isLE, bytes, offset) { return {offset: offset + 4, value: bytes.getUint32(offset, isLE)}; });
+var _Bytes_read_f32 = F3(function(isLE, bytes, offset) { return {offset: offset + 4, value: bytes.getFloat32(offset, isLE)}; });
+var _Bytes_read_f64 = F3(function(isLE, bytes, offset) { return {offset: offset + 8, value: bytes.getFloat64(offset, isLE)}; });
 
 var _Bytes_read_bytes = F3(function(len, bytes, offset)
 {
-	return __Utils_Tuple2(offset + len, new DataView(bytes.buffer, bytes.byteOffset + offset, len));
+	return {offset: offset + len, value: new DataView(bytes.buffer, bytes.byteOffset + offset, len)};
 });
 
 var _Bytes_read_string = F3(function(len, bytes, offset)
@@ -179,7 +179,7 @@ var _Bytes_read_string = F3(function(len, bytes, offset)
 				, String.fromCharCode(Math.floor(byte / 0x400) + 0xD800, byte % 0x400 + 0xDC00)
 				);
 	}
-	return __Utils_Tuple2(offset, string);
+	return {offset: offset, value: string};
 });
 
 var _Bytes_decodeFailure = F2(function() { throw 0; });

--- a/src/Gren/Kernel/Bytes.js
+++ b/src/Gren/Kernel/Bytes.js
@@ -135,18 +135,18 @@ var _Bytes_decode = F2(function(decoder, bytes)
 	}
 });
 
-var _Bytes_read_i8  = F2(function(      bytes, offset) { return {offset: offset + 1, value: bytes.getInt8(offset)}; });
-var _Bytes_read_i16 = F3(function(isLE, bytes, offset) { return {offset: offset + 2, value: bytes.getInt16(offset, isLE)}; });
-var _Bytes_read_i32 = F3(function(isLE, bytes, offset) { return {offset: offset + 4, value: bytes.getInt32(offset, isLE)}; });
-var _Bytes_read_u8  = F2(function(      bytes, offset) { return {offset: offset + 1, value: bytes.getUint8(offset)}; });
-var _Bytes_read_u16 = F3(function(isLE, bytes, offset) { return {offset: offset + 2, value: bytes.getUint16(offset, isLE)}; });
-var _Bytes_read_u32 = F3(function(isLE, bytes, offset) { return {offset: offset + 4, value: bytes.getUint32(offset, isLE)}; });
-var _Bytes_read_f32 = F3(function(isLE, bytes, offset) { return {offset: offset + 4, value: bytes.getFloat32(offset, isLE)}; });
-var _Bytes_read_f64 = F3(function(isLE, bytes, offset) { return {offset: offset + 8, value: bytes.getFloat64(offset, isLE)}; });
+var _Bytes_read_i8  = F2(function(      bytes, offset) { return {__$offset: offset + 1, __$value: bytes.getInt8(offset)}; });
+var _Bytes_read_i16 = F3(function(isLE, bytes, offset) { return {__$offset: offset + 2, __$value: bytes.getInt16(offset, isLE)}; });
+var _Bytes_read_i32 = F3(function(isLE, bytes, offset) { return {__$offset: offset + 4, __$value: bytes.getInt32(offset, isLE)}; });
+var _Bytes_read_u8  = F2(function(      bytes, offset) { return {__$offset: offset + 1, __$value: bytes.getUint8(offset)}; });
+var _Bytes_read_u16 = F3(function(isLE, bytes, offset) { return {__$offset: offset + 2, __$value: bytes.getUint16(offset, isLE)}; });
+var _Bytes_read_u32 = F3(function(isLE, bytes, offset) { return {__$offset: offset + 4, __$value: bytes.getUint32(offset, isLE)}; });
+var _Bytes_read_f32 = F3(function(isLE, bytes, offset) { return {__$offset: offset + 4, __$value: bytes.getFloat32(offset, isLE)}; });
+var _Bytes_read_f64 = F3(function(isLE, bytes, offset) { return {__$offset: offset + 8, __$value: bytes.getFloat64(offset, isLE)}; });
 
 var _Bytes_read_bytes = F3(function(len, bytes, offset)
 {
-	return {offset: offset + len, value: new DataView(bytes.buffer, bytes.byteOffset + offset, len)};
+	return {__$offset: offset + len, __$value: new DataView(bytes.buffer, bytes.byteOffset + offset, len)};
 });
 
 var _Bytes_read_string = F3(function(len, bytes, offset)
@@ -179,7 +179,7 @@ var _Bytes_read_string = F3(function(len, bytes, offset)
 				, String.fromCharCode(Math.floor(byte / 0x400) + 0xD800, byte % 0x400 + 0xDC00)
 				);
 	}
-	return {offset: offset, value: string};
+	return {__$offset: offset, __$value: string};
 });
 
 var _Bytes_decodeFailure = F2(function() { throw 0; });

--- a/src/Gren/Kernel/Bytes.js
+++ b/src/Gren/Kernel/Bytes.js
@@ -129,7 +129,7 @@ var _Bytes_write_string = F3(function(mb, offset, string)
 var _Bytes_decode = F2(function(decoder, bytes)
 {
 	try {
-		return __Maybe_Just(A2(decoder, bytes, 0).value);
+		return __Maybe_Just(A2(decoder, bytes, 0).__$value);
 	} catch(e) {
 		return __Maybe_Nothing;
 	}


### PR DESCRIPTION
Bytes.Decode does not currently work and crashes if you try to use returned value.
This is because the Kernel code reference some tuple stuff.
This change makes Bytes.Decode work as expected